### PR TITLE
This commit implements the `requestUpload` (0x35) UDS service. It inc…

### DIFF
--- a/Sources/Swift-UDS-Session/DiagnosticSession.swift
+++ b/Sources/Swift-UDS-Session/DiagnosticSession.swift
@@ -107,6 +107,12 @@ extension UDS {
             try await self.request(service: .requestDownload(compression: compression, encryption: encryption, address: address, length: length))
         }
         
+        /// Initiate a block transfer (ECU -> TESTER)
+        @discardableResult
+        public func requestUpload(compression: UInt8, encryption: UInt8, address: [UInt8], length: [UInt8]) async throws -> UDS.GenericResponse {
+            try await self.request(service: .requestUpload(compression: compression, encryption: encryption, address: address, length: length))
+        }
+
         /// Trigger a routine
         @discardableResult
         public func routineControl(type: UDS.RoutineControlType, identifier: UDS.RoutineIdentifier, optionRecord: DataRecord = []) async throws -> UDS.GenericResponse {

--- a/Sources/Swift-UDS/Core/Services.swift
+++ b/Sources/Swift-UDS/Core/Services.swift
@@ -31,6 +31,7 @@ public extension UDS {
         case readDataByIdentifier(id: DataIdentifier)
         case readDTCByStatusMask(mask: DTC.StatusMask)
         case requestDownload(compression: Compression, encryption: Encryption, address: TransferAddress, length: TransferLength)
+        case requestUpload(compression: Compression, encryption: Encryption, address: TransferAddress, length: TransferLength)
         case requestTransferExit(trpr: DataRecord = [])
         case routineControl(type: RoutineControlType, id: RoutineIdentifier, rcor: DataRecord)
         case securityAccessRequestSeed(level: UInt8)
@@ -125,6 +126,15 @@ public extension UDS {
                     guard length.count < 0x10 else { return [] }
                     let alfid: UDS.AddressAndLengthFormatIdentifier = ((UInt8(address.count) & 0x0F) << 4) | (UInt8(length.count) & 0x0F)
                     return [UDS.ServiceId.requestDownload, dfi, alfid] + address + length
+
+                case .requestUpload(compression: let compression, encryption: let encryption, address: let address, length: let length):
+                    guard compression < 0x10 else { return [] }
+                    guard encryption < 0x10 else { return [] }
+                    let dfi: UDS.DataFormatIdentifier = ((compression & 0x0F) << 4) | (encryption & 0x0F)
+                    guard address.count < 0x10 else { return [] }
+                    guard length.count < 0x10 else { return [] }
+                    let alfid: UDS.AddressAndLengthFormatIdentifier = ((UInt8(address.count) & 0x0F) << 4) | (UInt8(length.count) & 0x0F)
+                    return [UDS.ServiceId.requestUpload, dfi, alfid] + address + length
 
                 case .requestTransferExit(trpr: let tprp):
                     return [UDS.ServiceId.requestTransferExit] + tprp

--- a/Tests/SwiftUDSTests/SwiftUDSTests.swift
+++ b/Tests/SwiftUDSTests/SwiftUDSTests.swift
@@ -2,10 +2,34 @@ import XCTest
 @testable import Swift_UDS
 
 final class SwiftUDSTests: XCTestCase {
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual("Hello World!", "Hello, World!")
+
+    func testDiagnosticSessionControlPayload() {
+        let service = UDS.Service.diagnosticSessionControl(session: .extended)
+        let payload = service.payload
+        XCTAssertEqual(payload, [0x10, 0x03], "The payload for diagnosticSessionControl is incorrect.")
+    }
+
+    func testEcuResetPayload() {
+        let service = UDS.Service.ecuReset(type: .hardReset)
+        let payload = service.payload
+        XCTAssertEqual(payload, [0x11, 0x01], "The payload for ecuReset is incorrect.")
+    }
+
+    func testReadDataByIdentifierPayload() {
+        let service = UDS.Service.readDataByIdentifier(id: 0x1234)
+        let payload = service.payload
+        XCTAssertEqual(payload, [0x22, 0x12, 0x34], "The payload for readDataByIdentifier is incorrect.")
+    }
+
+    func testWriteDataByIdentifierPayload() {
+        let service = UDS.Service.writeDataByIdentifier(id: 0x5678, drec: [0xDE, 0xAD, 0xBE, 0xEF])
+        let payload = service.payload
+        XCTAssertEqual(payload, [0x2E, 0x56, 0x78, 0xDE, 0xAD, 0xBE, 0xEF], "The payload for writeDataByIdentifier is incorrect.")
+    }
+
+    func testRequestUploadPayload() {
+        let service = UDS.Service.requestUpload(compression: 0, encryption: 0, address: [0x12, 0x34], length: [0x56, 0x78])
+        let payload = service.payload
+        XCTAssertEqual(payload, [0x35, 0x00, 0x22, 0x12, 0x34, 0x56, 0x78], "The payload for requestUpload is incorrect.")
     }
 }


### PR DESCRIPTION
…ludes the addition of the service to the `UDS.Service` enum, the implementation of its payload generation logic, a high-level convenience method in `DiagnosticSession`, and a unit test to verify the correctness of the generated payload.