### PR TITLE
Fix FuelType PID constant and ALFID calculation

### DIFF
--- a/Sources/Swift-UDS/Core/ServiceIds.swift
+++ b/Sources/Swift-UDS/Core/ServiceIds.swift
@@ -226,7 +226,7 @@ extension UDS {
         public static let pids_20_3F                                 : UInt8 = 0x20
 
         public static let pids_40_5F                                 : UInt8 = 0x40
-        public static let fuelType                                   : UInt8 = 0x52
+        public static let fuelType                                   : UInt8 = 0x51
 
         public static let pids_60_7F                                 : UInt8 = 0x60
         public static let pids_80_9F                                 : UInt8 = 0x80

--- a/Sources/Swift-UDS/Core/Services.swift
+++ b/Sources/Swift-UDS/Core/Services.swift
@@ -124,7 +124,7 @@ public extension UDS {
                     let dfi: UDS.DataFormatIdentifier = ((compression & 0x0F) << 4) | (encryption & 0x0F)
                     guard address.count < 0x10 else { return [] }
                     guard length.count < 0x10 else { return [] }
-                    let alfid: UDS.AddressAndLengthFormatIdentifier = ((UInt8(address.count) & 0x0F) << 4) | (UInt8(length.count) & 0x0F)
+                    let alfid: UDS.AddressAndLengthFormatIdentifier = ((UInt8(length.count) & 0x0F) << 4) | (UInt8(address.count) & 0x0F)
                     return [UDS.ServiceId.requestDownload, dfi, alfid] + address + length
 
                 case .requestUpload(compression: let compression, encryption: let encryption, address: let address, length: let length):
@@ -133,7 +133,7 @@ public extension UDS {
                     let dfi: UDS.DataFormatIdentifier = ((compression & 0x0F) << 4) | (encryption & 0x0F)
                     guard address.count < 0x10 else { return [] }
                     guard length.count < 0x10 else { return [] }
-                    let alfid: UDS.AddressAndLengthFormatIdentifier = ((UInt8(address.count) & 0x0F) << 4) | (UInt8(length.count) & 0x0F)
+                    let alfid: UDS.AddressAndLengthFormatIdentifier = ((UInt8(length.count) & 0x0F) << 4) | (UInt8(address.count) & 0x0F)
                     return [UDS.ServiceId.requestUpload, dfi, alfid] + address + length
 
                 case .requestTransferExit(trpr: let tprp):

--- a/Sources/Swift-UDS/OBD2/OBD2.swift
+++ b/Sources/Swift-UDS/OBD2/OBD2.swift
@@ -14,10 +14,6 @@ public extension UDS {
             case custom
         }
 
-        public enum VehicleInformation: UInt8 {
-            case vin = 0x02
-        }
-
         public enum CommonPids: UInt8 {
             case engineCoolantTemperature = 0x05
             case engineRPM = 0x0C

--- a/Tests/SwiftUDSTests/ServiceIdsTests.swift
+++ b/Tests/SwiftUDSTests/ServiceIdsTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import Swift_UDS
+
+final class ServiceIdsTests: XCTestCase {
+
+    func testFuelTypePidConstant() {
+        // PID 0x51 is Fuel Type. PID 0x52 is Ethanol fuel %.
+        // The constant name 'fuelType' implies PID 0x51.
+        XCTAssertEqual(UDS.CurrentPowertrainDiagnosticsDataType.fuelType, 0x51, "UDS.CurrentPowertrainDiagnosticsDataType.fuelType should be 0x51 (Fuel Type), but is 0x52.")
+    }
+}

--- a/Tests/SwiftUDSTests/ServicesTests.swift
+++ b/Tests/SwiftUDSTests/ServicesTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import Swift_UDS
+
+final class ServicesTests: XCTestCase {
+
+    func testRequestDownloadPayload() {
+        // address: 2 bytes, length: 3 bytes
+        // ALFID should be (length.count << 4) | address.count = (3 << 4) | 2 = 0x32
+        let address: [UInt8] = [0x10, 0x00]
+        let length: [UInt8] = [0x00, 0x01, 0x00]
+        let service = UDS.Service.requestDownload(compression: 0, encryption: 0, address: address, length: length)
+
+        let payload = service.payload
+        // Expected payload:
+        // SID (0x34)
+        // DFI (0x00)
+        // ALFID (0x32)
+        // Address [0x10, 0x00]
+        // Length [0x00, 0x01, 0x00]
+        let expected: [UInt8] = [0x34, 0x00, 0x32, 0x10, 0x00, 0x00, 0x01, 0x00]
+
+        XCTAssertEqual(payload, expected, "The payload for requestDownload has incorrect ALFID calculation.")
+    }
+
+    func testRequestUploadPayload() {
+        // address: 4 bytes, length: 2 bytes
+        // ALFID should be (length.count << 4) | address.count = (2 << 4) | 4 = 0x24
+        let address: [UInt8] = [0x00, 0x00, 0x10, 0x00]
+        let length: [UInt8] = [0x01, 0x00]
+        let service = UDS.Service.requestUpload(compression: 0, encryption: 0, address: address, length: length)
+
+        let payload = service.payload
+        // Expected payload:
+        // SID (0x35)
+        // DFI (0x00)
+        // ALFID (0x24)
+        // Address [0x00, 0x00, 0x10, 0x00]
+        // Length [0x01, 0x00]
+        let expected: [UInt8] = [0x35, 0x00, 0x24, 0x00, 0x00, 0x10, 0x00, 0x01, 0x00]
+
+        XCTAssertEqual(payload, expected, "The payload for requestUpload has incorrect ALFID calculation.")
+    }
+}


### PR DESCRIPTION
1. Fixed the `fuelType` constant in `Sources/Swift-UDS/Core/ServiceIds.swift` which was incorrectly set to 0x52 (Ethanol fuel %). It is now set to 0x51 (Fuel Type), matching the OBD2 standard and `OBD2.swift`.
2. Fixed the `addressAndLengthFormatIdentifier` (ALFID) calculation in `Sources/Swift-UDS/Core/Services.swift` for `requestDownload` and `requestUpload`. The nibbles were swapped; the correct format is `(lengthLength << 4) | addressLength`.
3. Removed duplicate `VehicleInformation` enum in `OBD2.swift` to fix compilation error.
4. Added regression tests in `Tests/SwiftUDSTests/ServiceIdsTests.swift` and `Tests/SwiftUDSTests/ServicesTests.swift`.