### PR TITLE
Implement KWP2000 Encoder (ISO 14230-4)

### DIFF
--- a/Sources/Swift-UDS/Protocols/KWP.swift
+++ b/Sources/Swift-UDS/Protocols/KWP.swift
@@ -19,7 +19,40 @@ public extension UDS.KWP {
 
         /// Encode a byte stream by inserting the appropriate framing control bytes as per ISOTP
         public func encode(_ bytes: [UInt8]) throws -> [UInt8] {
-            throw UDS.Error.encoderError(string: "KWP encoding not yet implemented")
+            guard bytes.count > 0 else { throw UDS.Error.encoderError(string: "Message too small (0 bytes)") }
+            guard bytes.count < UDS.ISOTP.MaximumFrameSize else { throw UDS.Error.encoderError(string: "Message too long. Maximum ISOTP payload is 4095 (0xFFF) bytes") }
+
+            let framedPayload = bytes.count <= 7 ? self.encodeSingleFrame(payload: bytes) : self.encodeMultiFrame(payload: bytes)
+            return framedPayload
+        }
+
+        // encodes bytes to a single frame
+        private func encodeSingleFrame(payload: [UInt8]) -> [UInt8] {
+            let pci = UInt8(payload.count)
+            return [pci] + payload
+        }
+
+        // encodes bytes to multiple frames
+        private func encodeMultiFrame(payload: [UInt8]) -> [UInt8] {
+            var payload = payload
+            let pci = 0x1000 | UInt16(payload.count)
+            let pciHi = UInt8(pci >> 8 & 0xFF)
+            let pciLo = UInt8(pci & 0xFF)
+            let ff = [pciHi, pciLo] + payload[0..<6]
+            payload.removeFirst(6)
+            var bytes = ff
+            var cfPci = UInt8(0x21)
+            while payload.count > 0 {
+                let cfPayloadCount = min(7, payload.count)
+                let cf = [cfPci] + payload[0..<cfPayloadCount]
+                payload.removeFirst(cfPayloadCount)
+                bytes += cf
+                cfPci = cfPci + 1
+                if cfPci == 0x30 {
+                    cfPci = 0x20
+                }
+            }
+            return bytes
         }
     }
 

--- a/Tests/SwiftUDSTests/KWPTests.swift
+++ b/Tests/SwiftUDSTests/KWPTests.swift
@@ -1,0 +1,79 @@
+//
+//  KWPTests.swift
+//  SwiftUDSTests
+//
+
+import XCTest
+@testable import Swift_UDS
+
+final class KWPTests: XCTestCase {
+
+    func testSingleFrameEncoding() throws {
+        let encoder = UDS.KWP.Encoder()
+        let payload: [UInt8] = [0x01, 0x02, 0x03]
+        let encoded = try encoder.encode(payload)
+        // Expect [0x03, 0x01, 0x02, 0x03] (PCI=03, Data)
+        XCTAssertEqual(encoded, [0x03, 0x01, 0x02, 0x03])
+    }
+
+    func testMultiFrameEncoding() throws {
+        let encoder = UDS.KWP.Encoder()
+        // Create a payload of 10 bytes (more than 7, triggers FF/CF)
+        let payload = Array<UInt8>(repeating: 0xAA, count: 10)
+        let encoded = try encoder.encode(payload)
+
+        // First Frame (FF):
+        // PCI = 0x100A (1AAA AAAA AAAA) -> 10 0A
+        // Data: AA AA AA AA AA AA (6 bytes)
+        // Total FF: 10 0A AA AA AA AA AA AA (8 bytes)
+
+        // Consecutive Frame (CF):
+        // PCI = 0x21 (Sequence Number starts at 1)
+        // Data: AA AA AA AA (4 bytes remaining)
+        // Total CF: 21 AA AA AA AA (5 bytes)
+
+        let expectedFF: [UInt8] = [0x10, 0x0A, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA]
+        let expectedCF: [UInt8] = [0x21, 0xAA, 0xAA, 0xAA, 0xAA]
+
+        // The encoder returns all frames concatenated
+        XCTAssertEqual(encoded.count, 8 + 5)
+        XCTAssertEqual(Array(encoded[0..<8]), expectedFF)
+        XCTAssertEqual(Array(encoded[8...]), expectedCF)
+    }
+
+    func testExactlySevenBytesEncoding() throws {
+        let encoder = UDS.KWP.Encoder()
+        let payload = Array<UInt8>(repeating: 0xBB, count: 7)
+        let encoded = try encoder.encode(payload)
+
+        // Expect Single Frame: PCI=07, Data=BB...
+        // [0x07, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB]
+        var expected: [UInt8] = [0x07]
+        expected.append(contentsOf: payload)
+
+        XCTAssertEqual(encoded, expected)
+    }
+
+    func testEmptyEncoding() {
+        let encoder = UDS.KWP.Encoder()
+        XCTAssertThrowsError(try encoder.encode([])) { error in
+            if let udsError = error as? UDS.Error, case .encoderError = udsError {
+                // Success
+            } else {
+                XCTFail("Expected UDS.Error.encoderError")
+            }
+        }
+    }
+
+    func testTooLargeEncoding() {
+        let encoder = UDS.KWP.Encoder()
+        let payload = Array<UInt8>(repeating: 0x00, count: 4096)
+        XCTAssertThrowsError(try encoder.encode(payload)) { error in
+            if let udsError = error as? UDS.Error, case .encoderError = udsError {
+                // Success
+            } else {
+                XCTFail("Expected UDS.Error.encoderError")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented the `encode` method in `UDS.KWP.Encoder` following ISO 14230-4 / ISO 15765-2 (ISO-TP) standards. This enables proper segmentation of KWP2000 messages over CAN, handling both Single Frame and Multi-Frame messages.

- Implemented `encode` with Single Frame and Multi-Frame logic.
- Added unit tests in `Tests/SwiftUDSTests/KWPTests.swift` covering various payload sizes and edge cases.